### PR TITLE
Fixes #8

### DIFF
--- a/m3u_parser/m3u_parser.py
+++ b/m3u_parser/m3u_parser.py
@@ -259,7 +259,7 @@ class M3uParser:
             try:
                 self.__streams_info = list(
                     filter(
-                        lambda stream_info: any(
+                        lambda stream_info: all(
                             [
                                 not re.search(
                                     re.compile(fltr, flags=re.IGNORECASE),


### PR DESCRIPTION
The issue #8 happens because M3uParser is using the `any` function when `retrieve=False` in [line 262](https://github.com/pawanpaudel93/m3u_parser/blob/36273e0c3cdfd3fc595361947509c98e234920b7/m3u_parser/m3u_parser.py#L262).

This PR fixes it by using `all`.